### PR TITLE
Add heads up warning option

### DIFF
--- a/Code/TicTacToeControl.Designer.cs
+++ b/Code/TicTacToeControl.Designer.cs
@@ -33,6 +33,7 @@
             btnStart = new Button();
             optTwoPlayer = new RadioButton();
             optPlayComputer = new RadioButton();
+            chkHeadsUp = new CheckBox();
             lblStatus = new Label();
             tblSpots = new TableLayoutPanel();
             btn1 = new Button();
@@ -77,6 +78,7 @@
             tblToolbar.Controls.Add(btnStart, 0, 0);
             tblToolbar.Controls.Add(optTwoPlayer, 1, 0);
             tblToolbar.Controls.Add(optPlayComputer, 2, 0);
+            tblToolbar.Controls.Add(chkHeadsUp, 3, 0);
             tblToolbar.Controls.Add(lblStatus, 0, 1);
             tblToolbar.Dock = DockStyle.Fill;
             tblToolbar.Location = new Point(3, 3);
@@ -121,9 +123,20 @@
             optPlayComputer.TabIndex = 2;
             optPlayComputer.Text = "Play &Against the Computer";
             optPlayComputer.UseVisualStyleBackColor = true;
-            // 
+            //
+            // chkHeadsUp
+            //
+            chkHeadsUp.Anchor = AnchorStyles.Left;
+            chkHeadsUp.AutoSize = true;
+            chkHeadsUp.Location = new Point(813, 3);
+            chkHeadsUp.Name = "chkHeadsUp";
+            chkHeadsUp.Size = new Size(146, 54);
+            chkHeadsUp.TabIndex = 3;
+            chkHeadsUp.Text = "Heads Up";
+            chkHeadsUp.UseVisualStyleBackColor = true;
+            //
             // lblStatus
-            // 
+            //
             lblStatus.BackColor = Color.LightYellow;
             lblStatus.BorderStyle = BorderStyle.FixedSingle;
             tblToolbar.SetColumnSpan(lblStatus, 4);
@@ -131,7 +144,7 @@
             lblStatus.Location = new Point(3, 60);
             lblStatus.Name = "lblStatus";
             lblStatus.Size = new Size(956, 61);
-            lblStatus.TabIndex = 3;
+            lblStatus.TabIndex = 4;
             lblStatus.TextAlign = ContentAlignment.MiddleCenter;
             // 
             // tblSpots
@@ -273,6 +286,7 @@
         protected Button btnStart;
         protected RadioButton optTwoPlayer;
         protected RadioButton optPlayComputer;
+        protected CheckBox chkHeadsUp;
         protected Label lblStatus;
         protected TableLayoutPanel tblSpots;
         protected Button btn1;

--- a/Code/TicTacToeControl.cs
+++ b/Code/TicTacToeControl.cs
@@ -23,6 +23,7 @@ namespace TicTacToe
         List<Button> lstrankedbuttons;
 
         Color defaultbackcolor;
+        Color defaultforecolor;
         bool playcomputer = false;
 
         public TicTacToeControl()
@@ -30,6 +31,7 @@ namespace TicTacToe
             InitializeComponent();
             lblName.Text = "MG";
             defaultbackcolor = btn1.BackColor;
+            defaultforecolor = btn1.ForeColor;
             lstbuttons = new() { btn1, btn2, btn3, btn4, btn5, btn6, btn7, btn8, btn9 };
 
             lstbuttons.ForEach(b => b.Click += SpotButton_Click);
@@ -59,7 +61,12 @@ namespace TicTacToe
 
         private void StartGame()
         {
-            lstbuttons.ForEach(b => { b.Text = ""; b.Enabled = true; });
+            lstbuttons.ForEach(b =>
+            {
+                b.Text = "";
+                b.Enabled = true;
+                b.ForeColor = defaultforecolor;
+            });
             gamestatus = GameStatusEnum.Playing;
             currentturn = TurnEnum.X;
             playcomputer = optPlayComputer.Checked;
@@ -194,6 +201,21 @@ namespace TicTacToe
             }
             lst.ForEach(b => b.BackColor = c);
         }
+
+        private bool IsAboutToLose(TurnEnum player)
+        {
+            var opponent = player == TurnEnum.X ? TurnEnum.O : TurnEnum.X;
+            return lstwinningsets.Any(l =>
+                l.Count(b => b.Text == opponent.ToString()) == 2 &&
+                l.Count(b => b.Text == "") == 1);
+        }
+
+        private void SetPlayerPiecesColor(TurnEnum player, Color color)
+        {
+            lstbuttons.Where(b => b.Text == player.ToString())
+                .ToList()
+                .ForEach(b => b.ForeColor = color);
+        }
         private void DisplayGameStatus()
         {
             string msg = "Click Start to begin Game";
@@ -214,6 +236,13 @@ namespace TicTacToe
             msg = (playcomputer ? optPlayComputer.Text : optTwoPlayer.Text) + " - " + msg;
 
             lblStatus.Text = msg;
+
+            lstbuttons.ForEach(b => b.ForeColor = defaultforecolor);
+            if (chkHeadsUp.Checked && gamestatus == GameStatusEnum.Playing && IsAboutToLose(currentturn))
+            {
+                lblStatus.Text += " - heads up";
+                SetPlayerPiecesColor(currentturn, Color.Orange);
+            }
         }
         private void SpotButton_Click(object? sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- add a `Heads Up` checkbox to enable warnings
- detect when the current player is about to lose
- show "heads up" message and color that player's pieces orange when enabled

## Testing
- `dotnet build Code/TicTacToe.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685466fa57648330aed22ddc0f3cdce5