### PR TITLE
Add losing warning feature

### DIFF
--- a/Code/TicTacToeControl.Designer.cs
+++ b/Code/TicTacToeControl.Designer.cs
@@ -44,6 +44,7 @@
             btn7 = new Button();
             btn8 = new Button();
             btn9 = new Button();
+            chkWarnAboutToLose = new CheckBox();
             lblName = new Label();
             tblMain.SuspendLayout();
             tblToolbar.SuspendLayout();
@@ -69,7 +70,8 @@
             // 
             // tblToolbar
             // 
-            tblToolbar.ColumnCount = 4;
+            tblToolbar.ColumnCount = 5;
+            tblToolbar.ColumnStyles.Add(new ColumnStyle());
             tblToolbar.ColumnStyles.Add(new ColumnStyle());
             tblToolbar.ColumnStyles.Add(new ColumnStyle());
             tblToolbar.ColumnStyles.Add(new ColumnStyle());
@@ -77,6 +79,7 @@
             tblToolbar.Controls.Add(btnStart, 0, 0);
             tblToolbar.Controls.Add(optTwoPlayer, 1, 0);
             tblToolbar.Controls.Add(optPlayComputer, 2, 0);
+            tblToolbar.Controls.Add(chkWarnAboutToLose, 3, 0);
             tblToolbar.Controls.Add(lblStatus, 0, 1);
             tblToolbar.Dock = DockStyle.Fill;
             tblToolbar.Location = new Point(3, 3);
@@ -121,12 +124,23 @@
             optPlayComputer.TabIndex = 2;
             optPlayComputer.Text = "Play &Against the Computer";
             optPlayComputer.UseVisualStyleBackColor = true;
-            // 
+            //
+            // chkWarnAboutToLose
+            //
+            chkWarnAboutToLose.Anchor = AnchorStyles.Left;
+            chkWarnAboutToLose.AutoSize = true;
+            chkWarnAboutToLose.Location = new Point(813, 3);
+            chkWarnAboutToLose.Name = "chkWarnAboutToLose";
+            chkWarnAboutToLose.Size = new Size(180, 54);
+            chkWarnAboutToLose.TabIndex = 3;
+            chkWarnAboutToLose.Text = "Warn If Lose";
+            chkWarnAboutToLose.UseVisualStyleBackColor = true;
+            //
             // lblStatus
-            // 
+            //
             lblStatus.BackColor = Color.LightYellow;
             lblStatus.BorderStyle = BorderStyle.FixedSingle;
-            tblToolbar.SetColumnSpan(lblStatus, 4);
+            tblToolbar.SetColumnSpan(lblStatus, 5);
             lblStatus.Dock = DockStyle.Fill;
             lblStatus.Location = new Point(3, 60);
             lblStatus.Name = "lblStatus";
@@ -284,6 +298,7 @@
         protected Button btn7;
         protected Button btn8;
         protected Button btn9;
+        protected CheckBox chkWarnAboutToLose;
         protected Label lblName;
     }
 }

--- a/Code/TicTacToeControl.cs
+++ b/Code/TicTacToeControl.cs
@@ -23,6 +23,7 @@ namespace TicTacToe
         List<Button> lstrankedbuttons;
 
         Color defaultbackcolor;
+        Color defaultforecolor;
         bool playcomputer = false;
 
         public TicTacToeControl()
@@ -30,6 +31,7 @@ namespace TicTacToe
             InitializeComponent();
             lblName.Text = "MG";
             defaultbackcolor = btn1.BackColor;
+            defaultforecolor = btn1.ForeColor;
             lstbuttons = new() { btn1, btn2, btn3, btn4, btn5, btn6, btn7, btn8, btn9 };
 
             lstbuttons.ForEach(b => b.Click += SpotButton_Click);
@@ -59,7 +61,7 @@ namespace TicTacToe
 
         private void StartGame()
         {
-            lstbuttons.ForEach(b => { b.Text = ""; b.Enabled = true; });
+            lstbuttons.ForEach(b => { b.Text = ""; b.Enabled = true; b.ForeColor = defaultforecolor; });
             gamestatus = GameStatusEnum.Playing;
             currentturn = TurnEnum.X;
             playcomputer = optPlayComputer.Checked;
@@ -194,6 +196,11 @@ namespace TicTacToe
             }
             lst.ForEach(b => b.BackColor = c);
         }
+
+        private void SetPlayerPiecesForeColor(TurnEnum player, Color color)
+        {
+            lstbuttons.Where(b => b.Text == player.ToString()).ToList().ForEach(b => b.ForeColor = color);
+        }
         private void DisplayGameStatus()
         {
             string msg = "Click Start to begin Game";
@@ -212,6 +219,23 @@ namespace TicTacToe
             }
 
             msg = (playcomputer ? optPlayComputer.Text : optTwoPlayer.Text) + " - " + msg;
+
+            // reset colors before applying warning
+            SetPlayerPiecesForeColor(TurnEnum.X, defaultforecolor);
+            SetPlayerPiecesForeColor(TurnEnum.O, defaultforecolor);
+
+            if (chkWarnAboutToLose.Checked && gamestatus == GameStatusEnum.Playing)
+            {
+                TurnEnum opponent = currentturn == TurnEnum.X ? TurnEnum.O : TurnEnum.X;
+                bool aboutToLose = lstwinningsets.Any(l =>
+                    l.Count(b => b.Text == opponent.ToString()) == 2 &&
+                    l.Count(b => b.Text == "") == 1);
+                if (aboutToLose)
+                {
+                    msg = "Heads up";
+                    SetPlayerPiecesForeColor(currentturn, Color.Orange);
+                }
+            }
 
             lblStatus.Text = msg;
         }


### PR DESCRIPTION
## Summary
- add checkbox for losing warning
- highlight player's pieces in orange and show "Heads up" when about to lose

## Testing
- `dotnet build Code/TicTacToe.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859c7216b708330875c54e312499c54