### PR TITLE
Add warning before losing feature

### DIFF
--- a/Code/TicTacToeControl.Designer.cs
+++ b/Code/TicTacToeControl.Designer.cs
@@ -33,6 +33,7 @@
             btnStart = new Button();
             optTwoPlayer = new RadioButton();
             optPlayComputer = new RadioButton();
+            chkWarnLoss = new CheckBox();
             lblStatus = new Label();
             tblSpots = new TableLayoutPanel();
             btn1 = new Button();
@@ -69,7 +70,8 @@
             // 
             // tblToolbar
             // 
-            tblToolbar.ColumnCount = 4;
+            tblToolbar.ColumnCount = 5;
+            tblToolbar.ColumnStyles.Add(new ColumnStyle());
             tblToolbar.ColumnStyles.Add(new ColumnStyle());
             tblToolbar.ColumnStyles.Add(new ColumnStyle());
             tblToolbar.ColumnStyles.Add(new ColumnStyle());
@@ -77,6 +79,7 @@
             tblToolbar.Controls.Add(btnStart, 0, 0);
             tblToolbar.Controls.Add(optTwoPlayer, 1, 0);
             tblToolbar.Controls.Add(optPlayComputer, 2, 0);
+            tblToolbar.Controls.Add(chkWarnLoss, 3, 0);
             tblToolbar.Controls.Add(lblStatus, 0, 1);
             tblToolbar.Dock = DockStyle.Fill;
             tblToolbar.Location = new Point(3, 3);
@@ -121,17 +124,28 @@
             optPlayComputer.TabIndex = 2;
             optPlayComputer.Text = "Play &Against the Computer";
             optPlayComputer.UseVisualStyleBackColor = true;
-            // 
+            //
+            // chkWarnLoss
+            //
+            chkWarnLoss.Anchor = AnchorStyles.Left;
+            chkWarnLoss.AutoSize = true;
+            chkWarnLoss.Location = new Point(813, 3);
+            chkWarnLoss.Name = "chkWarnLoss";
+            chkWarnLoss.Size = new Size(146, 54);
+            chkWarnLoss.TabIndex = 3;
+            chkWarnLoss.Text = "Warn Me";
+            chkWarnLoss.UseVisualStyleBackColor = true;
+            //
             // lblStatus
-            // 
+            //
             lblStatus.BackColor = Color.LightYellow;
             lblStatus.BorderStyle = BorderStyle.FixedSingle;
-            tblToolbar.SetColumnSpan(lblStatus, 4);
+            tblToolbar.SetColumnSpan(lblStatus, 5);
             lblStatus.Dock = DockStyle.Fill;
             lblStatus.Location = new Point(3, 60);
             lblStatus.Name = "lblStatus";
             lblStatus.Size = new Size(956, 61);
-            lblStatus.TabIndex = 3;
+            lblStatus.TabIndex = 4;
             lblStatus.TextAlign = ContentAlignment.MiddleCenter;
             // 
             // tblSpots
@@ -273,6 +287,7 @@
         protected Button btnStart;
         protected RadioButton optTwoPlayer;
         protected RadioButton optPlayComputer;
+        protected CheckBox chkWarnLoss;
         protected Label lblStatus;
         protected TableLayoutPanel tblSpots;
         protected Button btn1;

--- a/Code/TicTacToeControl.cs
+++ b/Code/TicTacToeControl.cs
@@ -64,7 +64,10 @@ namespace TicTacToe
             currentturn = TurnEnum.X;
             playcomputer = optPlayComputer.Checked;
             DisplayGameStatus();
-            SetButtonsBackcolor(lstbuttons);
+            if (gamestatus == GameStatusEnum.Playing)
+            {
+                SetButtonsBackcolor(lstbuttons);
+            }
         }
 
 
@@ -198,10 +201,28 @@ namespace TicTacToe
         {
             string msg = "Click Start to begin Game";
 
+            if (gamestatus == GameStatusEnum.Playing)
+            {
+                SetButtonsBackcolor(lstbuttons);
+            }
+
             switch (gamestatus)
             {
                 case GameStatusEnum.Playing:
                     msg = "Current Turn: " + currentturn.ToString();
+
+                    if (chkWarnLoss.Checked)
+                    {
+                        TurnEnum opponent = currentturn == TurnEnum.X ? TurnEnum.O : TurnEnum.X;
+                        var warnSet = lstwinningsets.FirstOrDefault(l =>
+                            l.Count(b => b.Text == opponent.ToString()) == 2 &&
+                            l.Count(b => b.Text == "") == 1);
+                        if (warnSet != null)
+                        {
+                            warnSet.ForEach(b => b.BackColor = Color.Orange);
+                            msg = "Warning: Opponent can win!";
+                        }
+                    }
                     break;
                 case GameStatusEnum.Tie:
                     msg = "Tie";


### PR DESCRIPTION
## Summary
- add a Warn Me checkbox to TicTacToe control
- highlight threatening winning sets in orange and display warning
- reset board color only when the game is still being played

## Testing
- `dotnet build Code/TicTacToe.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d562900548330a7c2636bac55a3e9