### PR TITLE
Add scoreboard feature

### DIFF
--- a/Code/TicTacToeControl.Designer.cs
+++ b/Code/TicTacToeControl.Designer.cs
@@ -44,7 +44,7 @@
             btn7 = new Button();
             btn8 = new Button();
             btn9 = new Button();
-            lblName = new Label();
+            lblScoreboard = new Label();
             tblMain.SuspendLayout();
             tblToolbar.SuspendLayout();
             tblSpots.SuspendLayout();
@@ -56,7 +56,7 @@
             tblMain.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
             tblMain.Controls.Add(tblToolbar, 0, 0);
             tblMain.Controls.Add(tblSpots, 0, 1);
-            tblMain.Controls.Add(lblName, 0, 2);
+            tblMain.Controls.Add(lblScoreboard, 0, 2);
             tblMain.Dock = DockStyle.Fill;
             tblMain.Location = new Point(0, 0);
             tblMain.Name = "tblMain";
@@ -240,15 +240,15 @@
             btn9.TabIndex = 8;
             btn9.UseVisualStyleBackColor = true;
             // 
-            // lblName
+            // lblScoreboard
             // 
-            lblName.BackColor = Color.White;
-            lblName.Dock = DockStyle.Fill;
-            lblName.Location = new Point(3, 650);
-            lblName.Name = "lblName";
-            lblName.Size = new Size(962, 41);
-            lblName.TabIndex = 2;
-            lblName.TextAlign = ContentAlignment.MiddleCenter;
+            lblScoreboard.BackColor = Color.White;
+            lblScoreboard.Dock = DockStyle.Fill;
+            lblScoreboard.Location = new Point(3, 650);
+            lblScoreboard.Name = "lblScoreboard";
+            lblScoreboard.Size = new Size(962, 41);
+            lblScoreboard.TabIndex = 2;
+            lblScoreboard.TextAlign = ContentAlignment.MiddleCenter;
             // 
             // TicTacToeControl
             // 
@@ -284,6 +284,6 @@
         protected Button btn7;
         protected Button btn8;
         protected Button btn9;
-        protected Label lblName;
+        protected Label lblScoreboard;
     }
 }

--- a/Code/TicTacToeControl.cs
+++ b/Code/TicTacToeControl.cs
@@ -22,13 +22,17 @@ namespace TicTacToe
         List<List<Button>> lstwinningsets;
         List<Button> lstrankedbuttons;
 
+        int xWins = 0;
+        int oWins = 0;
+        int tieGames = 0;
+
         Color defaultbackcolor;
         bool playcomputer = false;
 
         public TicTacToeControl()
         {
             InitializeComponent();
-            lblName.Text = "MG";
+            lblScoreboard.Text = GetScoreboardText();
             defaultbackcolor = btn1.BackColor;
             lstbuttons = new() { btn1, btn2, btn3, btn4, btn5, btn6, btn7, btn8, btn9 };
 
@@ -65,6 +69,7 @@ namespace TicTacToe
             playcomputer = optPlayComputer.Checked;
             DisplayGameStatus();
             SetButtonsBackcolor(lstbuttons);
+            UpdateScoreboard();
         }
 
 
@@ -160,22 +165,31 @@ namespace TicTacToe
 
         private void DetectWinner(List<Button> lst)
         {
-            if (lst.Count(b => b.Text == currentturn.ToString()) == lst.Count())
+            if (gamestatus == GameStatusEnum.Playing && lst.Count(b => b.Text == currentturn.ToString()) == lst.Count())
             {
-                Color c = Color.Yellow;
                 gamestatus = GameStatusEnum.Winner;
                 SetButtonsBackcolor(lst);
-
+                if (currentturn == TurnEnum.X)
+                {
+                    xWins++;
+                }
+                else
+                {
+                    oWins++;
+                }
+                UpdateScoreboard();
             }
         }
 
 
         private void DetectTie()
         {
-            if (lstbuttons.Count(b => b.Text == "") == 0)
+            if (gamestatus == GameStatusEnum.Playing && lstbuttons.Count(b => b.Text == "") == 0)
             {
                 gamestatus = GameStatusEnum.Tie;
                 SetButtonsBackcolor(lstbuttons);
+                tieGames++;
+                UpdateScoreboard();
             }
         }
 
@@ -193,6 +207,16 @@ namespace TicTacToe
                     break;
             }
             lst.ForEach(b => b.BackColor = c);
+        }
+
+        private string GetScoreboardText()
+        {
+            return $"X Wins: {xWins}  O Wins: {oWins}  Ties: {tieGames}";
+        }
+
+        private void UpdateScoreboard()
+        {
+            lblScoreboard.Text = GetScoreboardText();
         }
         private void DisplayGameStatus()
         {

--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ player has a winning set, then the game results in a tie.
 **The full spec for this software is in the repo docs folder [tic-tac-toe-spec.md](docs/tic-tac-toe-spec.md)**
 
 ![Tic_Tac_Toe](https://github.com/user-attachments/assets/f138a579-e3d0-4f0f-a6b6-08e2a419d6c0)
+
+## New Feature: Scoreboard
+A running scoreboard below the board keeps track of X wins, O wins and ties across games.


### PR DESCRIPTION
## Summary
- add scoreboard state tracking wins and ties
- update board start logic to display running totals
- rename label for scoreboard
- document the scoreboard in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d5ae576e083308b3a6c24f2248f6e